### PR TITLE
perf: cancel the default validate of user-info to show page

### DIFF
--- a/packages/arco-template-all-pages/template/src/pages/user-info/index.tsx
+++ b/packages/arco-template-all-pages/template/src/pages/user-info/index.tsx
@@ -14,7 +14,8 @@ import styles from './style/index.module.less';
 function UserInfo() {
   const locale = useLocale();
   const userInfo = useSelector((state: ReducerState) => state.global.userInfo);
-  if (!userInfo) return null;
+  // cancel the default verification of user information
+  // if (!userInfo) return null;
   const tabList = [
     {
       key: 'overview',


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.
  
  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-pro/blob/master/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [x] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change

## Background and context

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

user-info页面默认校验了user信息返回null，导致无法看到默认的效果。

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Changelog(CN) | Changelog(EN) | Related issues | 
|取消user-info页面对user的校验 | Cancel the default verification of user information | -------------- |

## Checklist:

- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `master` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->