### PR TITLE
fix: vite-arco can usable with SwitchOmega

### DIFF
--- a/arco-design-pro-vite/package.json
+++ b/arco-design-pro-vite/package.json
@@ -6,7 +6,7 @@
     "start": "vite",
     "dev": "vite",
     "preview": "vite preview",
-    "build":"vite build",
+    "build": "vite build",
     "eslint": "eslint src/ --ext .ts,.tsx,.js,.jsx --fix --cache",
     "stylelint": "stylelint 'src/**/*.less' 'src/**/*.css' --fix --cache",
     "pre-commit": "pretty-quick --staged && npm run eslint && npm run stylelint",
@@ -54,14 +54,16 @@
     "husky": "^7.0.2",
     "less": "^4.1.2",
     "less-loader": "7.3.0",
-    "pretty-quick": "^3.1.2",
     "postcss-less": "4",
     "prettier": "^2.4.1",
+    "pretty-quick": "^3.1.2",
     "stylelint": "^14.1.0",
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-standard": "^24.0.0",
     "typescript": "^4.5.2",
-    "vite": "^2.6.14"
+    "vite": "^2.6.14",
+    "vite-plugin-host": "^1.0.2"
+
   },
   "browserslist": {
     "production": [

--- a/arco-design-pro-vite/vite.config.ts
+++ b/arco-design-pro-vite/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import svgrPlugin from '@arco-plugins/vite-plugin-svgr';
 import vitePluginForArco from '@arco-plugins/vite-react';
 import setting from './src/settings.json';
+import host from 'vite-plugin-host';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -20,6 +21,7 @@ export default defineConfig({
         'arcoblue-6': setting.themeColor,
       },
     }),
+    host(),
   ],
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
When using the arco-vite template, the page is inaccessible after the SwitchOmega agent is enabled