### PR TITLE
fix: Use `husky set` to add pre-commit command

### DIFF
--- a/arco-design-pro-cra/package.json
+++ b/arco-design-pro-cra/package.json
@@ -10,7 +10,7 @@
     "eslint": "eslint src/ --ext .ts,.tsx,.js,.jsx --fix --cache",
     "stylelint": "stylelint 'src/**/*.less' 'src/**/*.css' --fix --cache",
     "pre-commit": "pretty-quick --staged && npm run eslint && npm run stylelint",
-    "prepare": "husky install && husky add .husky/pre-commit 'npm run pre-commit'"
+    "prepare": "husky install && husky set .husky/pre-commit 'npm run pre-commit'"
   },
   "dependencies": {
     "@antv/data-set": "^0.11.8",

--- a/arco-design-pro-next/package.json
+++ b/arco-design-pro-next/package.json
@@ -9,7 +9,7 @@
     "eslint": "eslint src/ --ext .ts,.tsx,.js,.jsx --fix --cache",
     "stylelint": "stylelint 'src/**/*.less' 'src/**/*.css' --fix --cache",
     "pre-commit": "pretty-quick --staged && npm run eslint && npm run stylelint",
-    "prepare": "husky install && husky add .husky/pre-commit 'npm run pre-commit'"
+    "prepare": "husky install && husky set .husky/pre-commit 'npm run pre-commit'"
   },
   "dependencies": {
     "@antv/data-set": "^0.11.8",

--- a/arco-design-pro-vite/package.json
+++ b/arco-design-pro-vite/package.json
@@ -10,7 +10,7 @@
     "eslint": "eslint src/ --ext .ts,.tsx,.js,.jsx --fix --cache",
     "stylelint": "stylelint 'src/**/*.less' 'src/**/*.css' --fix --cache",
     "pre-commit": "pretty-quick --staged && npm run eslint && npm run stylelint",
-    "prepare": "husky install && husky add .husky/pre-commit 'npm run pre-commit'"
+    "prepare": "husky install && husky set .husky/pre-commit 'npm run pre-commit'"
   },
   "dependencies": {
     "@antv/data-set": "^0.11.8",


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.
  
  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-design-pro/blob/master/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change

## Background and context
every time the npm script command `prepare`(` "prepare": "husky install && husky add.husky/pre-commit 'npm run pre-commit'"`) is run, it will  cause husky to add another`npm run pre-commit` item to the `.husky/pre-commit` script, which is not what we want.
<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->
change `husky add` to `husky set`
## Changelog

| Changelog(CN) | Changelog(EN) | Related issues | 
| ------------- | ------------- | -------------- |

## Checklist:

- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `master` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->